### PR TITLE
Use application routes url helpers

### DIFF
--- a/lib/solidus_sitemap/solidus_defaults.rb
+++ b/lib/solidus_sitemap/solidus_defaults.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 module SolidusSitemap::SolidusDefaults
-  include Spree::Core::Engine.routes.url_helpers
+  # include Spree::Core::Engine.routes.url_helpers
+  include Rails.application.routes.url_helpers # Use application's own routes as solidus_frontend is now removed
   include Spree::BaseHelper # for meta_data
 
   def default_url_options

--- a/lib/solidus_sitemap/solidus_defaults.rb
+++ b/lib/solidus_sitemap/solidus_defaults.rb
@@ -6,7 +6,7 @@ module SolidusSitemap::SolidusDefaults
   include Spree::BaseHelper # for meta_data
 
   def default_url_options
-    { host: SitemapGenerator::Sitemap.default_host }
+    { host: SitemapGenerator::Sitemap.default_host, locale: I18n.locale == I18n.default_locale ? nil : I18n.locale }
   end
 
   def add_login(options = {})

--- a/solidus_sitemap.gemspec
+++ b/solidus_sitemap.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'sitemap_generator', '~> 6.0'
-  s.add_dependency 'solidus_core', '>= 2.0.0', '< 4'
+  s.add_dependency 'solidus_core', '>= 2.0.0'
   s.add_dependency 'solidus_support', '~> 0.5'
 
   s.add_development_dependency 'solidus_dev_support'


### PR DESCRIPTION
Solidus_frontendを外した後、
Spree::Core::Engine.routes.url_helpersではなくapplication自身のurl_helpersを使用する。